### PR TITLE
fix `dialog.directory` being ignored on Windows

### DIFF
--- a/src/nigui/private/windows/platform_impl.nim
+++ b/src/nigui/private/windows/platform_impl.nim
@@ -409,7 +409,7 @@ method run*(dialog: OpenFileDialog) =
   var ofn: OpenFileName
   ofn.lStructSize = OpenFileName.sizeOf.int32
   ofn.nMaxFile = maxCharacters
-  ofn.lpstrInitialDir = getCurrentDir().pUtf8ToUtf16()
+  ofn.lpstrInitialDir = dialog.directory.pUtf8ToUtf16()
   ofn.Flags = OFN_FILEMUSTEXIST
   if dialog.multiple:
     ofn.Flags = ofn.Flags or OFN_ALLOWMULTISELECT or OFN_EXPLORER
@@ -441,7 +441,7 @@ method run(dialog: SaveFileDialog) =
   var ofn: OpenFileName
   ofn.lStructSize = OpenFileName.sizeOf.int32
   ofn.nMaxFile = maxCharacters
-  ofn.lpstrInitialDir = getCurrentDir().pUtf8ToUtf16()
+  ofn.lpstrInitialDir = dialog.directory.pUtf8ToUtf16()
   if dialog.defaultExtension.len > 0:
     ofn.lpstrDefExt = pUtf8ToUtf16(dialog.defaultExtension)
     ofn.lpstrFilter = pUtf8ToUtf16(dialog.defaultExtension & "\0*." & dialog.defaultExtension & "\0All files\0*.*")


### PR DESCRIPTION
Closes #13 