### PR TITLE
Control keydown event propagation for window function

### DIFF
--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -232,7 +232,7 @@ type
     key*: Key
     unicode*: int
     character*: string # UTF-8 character
-  WindowKeyProc* = proc(event: WindowKeyEvent)
+  WindowKeyProc* = proc(event: WindowKeyEvent): bool
 
   # Control events:
 
@@ -552,7 +552,7 @@ method closeClick*(window: Window)
 
 method handleResizeEvent*(window: Window, event: ResizeEvent)
 
-method handleKeyDownEvent*(window: Window, event: WindowKeyEvent)
+method handleKeyDownEvent*(window: Window, event: WindowKeyEvent) : bool
 
 method handleDropFilesEvent*(window: Window, event: DropFilesEvent)
 
@@ -1310,11 +1310,12 @@ method handleDropFilesEvent(window: Window, event: DropFilesEvent) =
   if callback != nil:
     callback(event)
 
-method handleKeyDownEvent(window: Window, event: WindowKeyEvent) =
+method handleKeyDownEvent(window: Window, event: WindowKeyEvent): bool =
   # can be overriden by custom window
   let callback = window.onKeyDown
   if callback != nil:
-    callback(event)
+    return callback(event)
+  return false
 
 method onDispose(window: Window): WindowDisposeProc = window.fOnDispose
 method `onDispose=`(window: Window, callback: WindowDisposeProc) = window.fOnDispose = callback

--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -101,7 +101,7 @@ proc pWindowKeyPressSignal(widget: pointer, event: var GdkEventKey, data: pointe
   evt.unicode = unicode
 
   try:
-    window.handleKeyDownEvent(evt)
+    discard window.handleKeyDownEvent(evt)
   except:
     handleException()
 

--- a/src/nigui/private/windows/platform_impl.nim
+++ b/src/nigui/private/windows/platform_impl.nim
@@ -230,7 +230,8 @@ proc pHandleWMKEYDOWNOrWMCHAR(window: Window, control: Control, unicode: int, ke
   windowEvent.unicode = unicode
   windowEvent.character = unicode.pUnicodeCharToUtf8
 
-  window.handleKeyDownEvent(windowEvent)
+  if window.handleKeyDownEvent(windowEvent):
+    return true
 
   if control != nil:
     var controlEvent = new ControlKeyEvent


### PR DESCRIPTION
The keydown callback for windows now returns a boolean indicating
whether the event was handled and should not be passed on to the
control.

This is basically only a change for the windows platform because only there keydown events are handled by the window first and then passed to the control as far as I can see.

Maybe a unified event propagation across platforms would be nice for reproducable behaviour?
If that is prefered I could see what I can do to implement that.