### PR TITLE
Implement Container.remove method

### DIFF
--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -1951,15 +1951,15 @@ method add(container: Container, control: Control) =
   container.triggerRelayout()
 
 method remove(container: Container, control: Control) =
-  discard
-  # if container != control.fParentControl:
-    # raiseError("control can not be removed because it is not member of the container")
-  # else:
-    # let startIndex = control.fIndex
-    # container.childControls.del(control.fIndex)
-    # for i in startIndex..container.childControls.high:
-      # container.childControl[i].fIndex = i
-    # control.parentControl = nil
+  if cast[Control](container) != control.fParentControl:
+    raiseError("control can not be removed because it is not member of the container")
+  else:
+    let startIndex = control.fIndex
+    container.fChildControls.del(container.fChildControls.find(control))
+    for i in startIndex..container.childControls.high:
+      container.childControls[i].fIndex = i
+    container.triggerRelayout()
+    control.fParentControl = nil
 
 method setControlPosition(container: Container, control: Control, x, y: int) =
   control.setPosition(x, y)

--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -1201,6 +1201,10 @@ method add(container: ContainerImpl, control: Control) =
   gtk_container_add(container.fInnerHandle, cast[ControlImpl](control).fHandle)
   procCall container.Container.add(control)
 
+method remove(container: ContainerImpl, control: Control) =
+  gtk_container_remove(container.fInnerHandle, cast[ControlImpl](control).fHandle)
+  procCall container.Container.remove(control)
+
 method paddingLeft(container: ContainerImpl): int {.base.} = 5 # TODO
 method paddingRight(container: ContainerImpl): int {.base.} = 5 # TODO
 method paddingTop(container: ContainerImpl): int {.base.} = 15 # TODO


### PR DESCRIPTION
This implements `container.remove`. Fixes the commented out code from `nigui.nim` and implements the GTK backend for it. It is unclear to me why the code in `nigui.nim` was commented out, so if there is additional context please let me know.