### PR TITLE
Allow cross-compilation for Windows (on Linux)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,8 @@ jobs:
           nim-version: ${{ matrix.nim_version }}
 
       - name: Test examples
+        working-directory: examples
         run: |
-          cd examples
           for file in $(ls -v example_*nim); do
             echo "=== test: $file ==="
             nim c "$file"
@@ -109,11 +109,11 @@ jobs:
           nim -v
           nimble -v
       - name: Test examples
+        working-directory: examples
         run: |
-          cd examples
-          for file in $(ls -v example_*nim)
+          for cpu in amd64 i386
           do
-            for cpu in amd64 i386
+            for file in $(ls -v example_*nim)
             do
               echo "=== test: $file @$cpu ==="
               nim c -d:mingw -d:release --cpu:$cpu "$file"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
             for cpu in amd64 i386
             do
               echo "=== test: $file @$cpu ==="
-              nim c "$file"
+              nim c -d:mingw -d:release --cpu:$cpu "$file"
               echo ""
             done
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,10 @@ jobs:
             echo ""
           done
         shell: bash
+
+  mingw:
+    runs-on: ubuntu-latest
+    needs: before
+    steps:
+      - name: Install MinGW
+        run:  sudo apt install mingw-w64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           - 'stable'
     needs: before
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set cache-key
         id: vars
@@ -78,3 +78,45 @@ jobs:
     steps:
       - name: Install MinGW
         run:  sudo apt install mingw-w64
+
+      - uses: actions/checkout@v2
+
+      - name: Set cache-key
+        id: vars
+        run: echo ::set-output name=cache-key::$(date +%Y-%m-%d)
+
+      - name: Print cache-key
+        run: echo cache-key = ${{ steps.vars.outputs.cache-key }}
+
+      - name: Cache choosenim
+        id: cache-choosenim
+        uses: actions/cache@v1
+        with:
+          path: ~/.choosenim
+          key: ${{ runner.os }}-choosenim-${{ steps.vars.outputs.cache-key }}
+
+      - name: Cache nimble
+        id: cache-nimble
+        uses: actions/cache@v1
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+
+      - uses: jiro4989/setup-nim-action@v1
+
+      - name: Dump versions
+        run: |
+          nim -v
+          nimble -v
+      - name: Test examples
+        run: |
+          cd examples
+          for file in $(ls -v example_*nim)
+          do
+            for cpu in amd64 i386
+            do
+              echo "=== test: $file @$cpu ==="
+              nim c "$file"
+              echo ""
+            done
+          done

--- a/src/nigui/private/windows/platform_impl.nim
+++ b/src/nigui/private/windows/platform_impl.nim
@@ -9,13 +9,16 @@
 import windows
 import tables
 import dynlib
+import strformat
 
-# Link resource file to enable visual styles (without this, controls have Windows 95 look):
-when defined(cpu64):
-  {.link: currentSourcePath().parentDir() / "manifest_x64.res".}
-else:
-  {.link: currentSourcePath().parentDir() / "manifest_x86.res".}
-
+# Link resource file to enable visual styles 
+# (without this, controls have Windows 95 look):
+const
+  bitness = if defined(cpu64): 64 else: 86
+  resFile = (currentSourcePath() /../
+    &"manifest_x{bitness}.res").
+    replace('\\', '/')
+{.link: resFile.}
 
 # ----------------------------------------------------------------------------------------
 #                                    Internal Things


### PR DESCRIPTION
Quick-n-dirty hack to allow cross-compilation of NiGui apps [using mingw][cross]. 

It fails saying file `...\nigui-0.2.4\nigui\private\windows\manifest_x64.res` not found. Note backslashes in path. 

I believe this is error of Nim itself, but not sure. Any way it can be easily fixed by replacing all `\` to `/`. This works on Windows too.


[cross]: https://nim-lang.org/docs/nimc.html#cross-compilation-for-windows