### PR TITLE
Change quit behaviour

### DIFF
--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -355,6 +355,9 @@ proc init(app: App) =
 
 proc runMainLoop() = gtk_main()
 
+proc platformQuit() =
+  gtk_main_quit()
+
 proc processEvents(app: App) =
   while gtk_events_pending() == 1:
     discard gtk_main_iteration()

--- a/src/nigui/private/windows/platform_impl.nim
+++ b/src/nigui/private/windows/platform_impl.nim
@@ -36,6 +36,8 @@ var pLastMouseButtonDownControl: Control
 var pLastMouseButtonDownControlX: int
 var pLastMouseButtonDownControlY: int
 
+var appRunning: bool
+
 proc pRaiseLastOSError() =
   let e = osLastError()
   raiseError(strutils.strip(osErrorMsg(e)) & " (OS Error Code: " & $e & ")")
@@ -412,12 +414,16 @@ proc init(app: App) =
   app.defaultFontFamily = "Arial"
   fScrollbarSize = GetSystemMetrics(SM_CXVSCROLL)
   pEnableHighDpiSupport()
+  appRunning = true
 
 proc runMainLoop() =
   var msg: Msg
-  while GetMessageW(msg.addr, nil, 0, 0):
+  while GetMessageW(msg.addr, nil, 0, 0) and appRunning:
     discard TranslateMessage(msg.addr)
     discard DispatchMessageW(msg.addr)
+
+proc platformQuit() =
+  appRunning = false
 
 proc processEvents(app: App) =
   var msg: Msg


### PR DESCRIPTION
This changes the behavior of the `app.quit` procedure to only quit the GUI, not the entire program, unless the `quitApp` argument is true. This allows GUI to be used inline with other code execution.

I have made it so that it defaults to not quitting everything, since all existing code using NiGui should have nothing after `app.run()`, but if the maintainer wants this to be the other way round then let it be so.