### PR TITLE
Add queueMain (fixes #87)

### DIFF
--- a/examples/example_15_threading.nim
+++ b/examples/example_15_threading.nim
@@ -1,21 +1,24 @@
+# This example shows how to change a control from another thread
+
 import nigui
 
 var
-  win: Window
-  box: LayoutContainer
+  window: Window
+  container: LayoutContainer
   button: Button
   pbar: ProgressBar
+  thread: Thread[void]
 
 app.init()
 
-win = newWindow("Test")
+window = newWindow("NiGui Example")
 
-box = newLayoutContainer(Layout_Vertical)
-box.padding = 10
-win.add(box)
+container = newLayoutContainer(Layout_Vertical)
+container.padding = 10
+window.add(container)
 
 button = newButton("Start thread")
-box.add(button)
+container.add(button)
 
 proc update() =
   {.gcsafe.}:
@@ -27,15 +30,13 @@ proc start() =
   {.gcsafe.}:
     app.queueMain(update)
 
-var t: Thread[void]
-
 button.onClick = proc(event: ClickEvent) =
-  box.remove(button)
+  container.remove(button)
 
   pbar = newProgressBar()
-  box.add(pbar)
+  container.add(pbar)
 
-  createThread(t, start)
+  createThread(thread, start)
 
-win.show()
+window.show()
 app.run()

--- a/examples/example_15_threading.nim
+++ b/examples/example_15_threading.nim
@@ -1,0 +1,41 @@
+import nigui
+
+var
+  win: Window
+  box: LayoutContainer
+  button: Button
+  pbar: ProgressBar
+
+app.init()
+
+win = newWindow("Test")
+
+box = newLayoutContainer(Layout_Vertical)
+box.padding = 10
+win.add(box)
+
+button = newButton("Start thread")
+box.add(button)
+
+proc update() =
+  {.gcsafe.}:
+    pbar.value = pbar.value + 0.01
+    app.sleep(100)
+    app.queueMain(update)
+
+proc start() =
+  {.gcsafe.}:
+    app.queueMain(update)
+
+var t: Thread[void]
+
+button.onClick = proc(event: ClickEvent) =
+  box.remove(button)
+
+  pbar = newProgressBar()
+  box.add(pbar)
+
+  createThread(t, start)
+
+win.show()
+app.run()

--- a/examples/nim.cfg
+++ b/examples/nim.cfg
@@ -1,0 +1,1 @@
+--threads:on

--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -460,7 +460,7 @@ proc sleep*(app: App, milliSeconds: float)
 proc queueMain*(app: App, fn: proc()) ## \
 ## Queues `fn` to be executed on the GUI thread and returns immediately.
 ##
-## This is the only function that can be safely called from other threads.
+## This is the only function that can be safely called from other threads, and it must be called from a `{.gcsafe.}:` block.
 
 proc errorHandler*(app: App): ErrorHandlerProc
 proc `errorHandler=`*(app: App, errorHandler: ErrorHandlerProc)

--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -457,6 +457,8 @@ proc processEvents*(app: App)
 
 proc sleep*(app: App, milliSeconds: float)
 
+proc queueMain*(app: App, fn: proc())
+
 proc errorHandler*(app: App): ErrorHandlerProc
 proc `errorHandler=`*(app: App, errorHandler: ErrorHandlerProc)
 

--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -636,12 +636,12 @@ method endPixelDataAccess*(image: Image) {.base.}
 #                                        Window
 # ----------------------------------------------------------------------------------------
 
-proc newWindow*(title: string = ""): Window
+proc newWindow*(title: string = ""): Window ## \
 ## Constructor for a Window object.
 ## If the title is empty, it will be set to the application filename.
 
-proc init*(window: WindowImpl)
-## Initialize a WindowImpl object
+proc init*(window: WindowImpl) ## \
+## Initialize a WindowImpl object.
 ## Only needed for own constructors.
 
 proc dispose*(window: var Window)
@@ -695,7 +695,7 @@ method clientHeight*(window: Window): int {.base.}
 method iconPath*(window: Window): string {.base.}
 method `iconPath=`*(window: Window, iconPath: string) {.base, locks: "unknown".}
 
-method mousePosition*(window: Window): tuple[x, y: int]
+method mousePosition*(window: Window): tuple[x, y: int] ## \
 ## Returns the mouse pointer position relative to the given window
 
 method closeClick*(window: Window) {.base.}
@@ -787,7 +787,7 @@ method wantedWidth*(control: Control): int {.base.}
 
 method wantedHeight*(control: Control): int {.base.}
 
-method mousePosition*(control: Control): tuple[x, y: int]
+method mousePosition*(control: Control): tuple[x, y: int] ## \
 ## Returns the mouse pointer position relative to the given control
 
 method focus*(control: Control) {.base.}
@@ -1001,7 +1001,7 @@ proc init*(progressBar: ProgressBar)
 proc init*(progressBar: NativeProgressBar)
 
 method value*(progressBar: ProgressBar): float {.base.}
-method `value=`*(progressBar: ProgressBar, value: float) {.base.}
+method `value=`*(progressBar: ProgressBar, value: float) {.base.} ## \
 ## value should be between 0.0 and 1.0
 
 
@@ -1260,7 +1260,7 @@ proc scaleToDpi(val: int): int = (val * fSystemDpi) div defaultDpi
 proc scaleToDpi(val: float): float = val * fSystemDpi.float / defaultDpi.float
 
 proc convertLineBreaks(str: string): string =
-  ## Converts \n line breaks (LF) to \p line breaks (CRLF on Windows)
+  ## Converts \\n line breaks (LF) to \\p line breaks (CRLF on Windows)
   when useWindows():
     for i in 0..str.high:
       let curr = str[i]

--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -457,7 +457,10 @@ proc processEvents*(app: App)
 
 proc sleep*(app: App, milliSeconds: float)
 
-proc queueMain*(app: App, fn: proc())
+proc queueMain*(app: App, fn: proc()) ## \
+## Queues `fn` to be executed on the GUI thread and returns immediately.
+##
+## This is the only function that can be safely called from other threads.
 
 proc errorHandler*(app: App): ErrorHandlerProc
 proc `errorHandler=`*(app: App, errorHandler: ErrorHandlerProc)

--- a/src/nigui/private/gtk3/gtk3.nim
+++ b/src/nigui/private/gtk3/gtk3.nim
@@ -435,7 +435,6 @@ proc gtk_style_context_get_color*(context: pointer, state: cint, color: var GdkR
 
 proc gtk_border_new*(): pointer {.importc, libgtk3.}
 
-# proc gdk_threads_init*() {.importc, libgtk3.}
 proc gdk_threads_add_idle*(function, data: pointer): cint {.importc, libgtk3.}
 
 proc gtk_scrollbar_new*(orientation: cint, adjustment: pointer): pointer {.importc, libgtk3.}

--- a/src/nigui/private/gtk3/gtk3.nim
+++ b/src/nigui/private/gtk3/gtk3.nim
@@ -436,7 +436,7 @@ proc gtk_style_context_get_color*(context: pointer, state: cint, color: var GdkR
 proc gtk_border_new*(): pointer {.importc, libgtk3.}
 
 # proc gdk_threads_init*() {.importc, libgtk3.}
-# proc gdk_threads_add_idle*(function, data: pointer): cint {.importc, libgtk3.}
+proc gdk_threads_add_idle*(function, data: pointer): cint {.importc, libgtk3.}
 
 proc gtk_scrollbar_new*(orientation: cint, adjustment: pointer): pointer {.importc, libgtk3.}
 

--- a/src/nigui/private/windows/windows.nim
+++ b/src/nigui/private/windows/windows.nim
@@ -137,6 +137,8 @@ const
   VK_OEM_4* = 219
   VK_OEM_5* = 220
   VK_OEM_102* = 226
+  WM_USER* = 0x0400
+  WM_APP* = 0x8000
   WM_ACTIVATE* = 0x0006
   WM_CHANGEUISTATE* = 0x0127
   WM_CHAR* = 258
@@ -434,7 +436,7 @@ proc BeginPaint*(hWnd: pointer, lpPaint: var PaintStruct): pointer {.importc, li
 proc EndPaint*(hWnd: pointer, lpPaint: var PaintStruct): bool {.importc, libUser32.}
 proc SendMessageA*(hWnd: pointer, msg: int32, wParam, lParam: pointer): pointer {.importc, libUser32.}
 proc SendMessageW*(hWnd: pointer, msg: int32, wParam, lParam: pointer): pointer {.importc, libUser32.}
-proc PostMessageA*(hWnd: pointer, msg: int32, wParam, lParam: pointer): pointer {.importc, libUser32.}
+proc PostMessageA*(hWnd: pointer, msg: int32, wParam, lParam: pointer): bool {.importc, libUser32.}
 proc GetSysColor*(nIndex: int32): RGB32 {.importc, libUser32.}
 proc InvalidateRect*(hWnd: pointer, lpRect: ref Rect, bErase: bool): bool {.importc, libUser32.}
 proc PostQuitMessage*(nExitCode: int32) {.importc, libUser32.}


### PR DESCRIPTION
This implements a new function `queueMain()` for Windows and GTK3 (inspired by andlabs' [ui](https://github.com/andlabs/ui) package for Go), which makes it much easier to write threaded programs using NiGui and fixes #87.

An (unrealistic but simple) example of usage has been provided in `examples/example_15_threading.nim`.