### PR TITLE
Add queued()

### DIFF
--- a/src/nigui.nim
+++ b/src/nigui.nim
@@ -461,6 +461,14 @@ proc queueMain*(app: App, fn: proc()) ## \
 ## Queues `fn` to be executed on the GUI thread and returns immediately.
 ##
 ## This is the only function that can be safely called from other threads, and it must be called from a `{.gcsafe.}:` block.
+## Before a thread that has called this function returns, it should wait for all queued funcitons to be executed:
+##
+## .. code-block:: nim
+##    while app.queued() > 0:
+##      discard
+
+proc queued*(app: App): int ## \
+## Returns the number of functions queued to be executed on the GUI thread.
 
 proc errorHandler*(app: App): ErrorHandlerProc
 proc `errorHandler=`*(app: App, errorHandler: ErrorHandlerProc)

--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -338,7 +338,7 @@ proc pCreateFont(fontFamily: string, fontSize: float, fontBold: bool): pointer =
 #                                    App Procedures
 # ----------------------------------------------------------------------------------------
 
-var queue: int
+var pQueue: int
 
 proc init(app: App) =
   gtk_init(nil, nil)
@@ -368,17 +368,17 @@ proc runQueuedFn(data: pointer): cint {.exportc.} =
   var fn = cast[ptr proc()](data)
   fn[]()
   deallocShared(fn)
-  dec queue
+  dec pQueue
   return 0
 
 proc queueMain(app: App, fn: proc()) =
-  inc queue
+  inc pQueue
   var p = cast[ptr proc()](allocShared0(sizeof(proc())))
   p[] = fn
   discard gdk_threads_add_idle(runQueuedFn, p)
 
 proc queued(app: App): int =
-  return queue
+  return pQueue
 
 proc pClipboardTextReceivedFunc(clipboard: pointer, text: cstring, data: pointer): Gboolean {.cdecl.} =
   pClipboardText = $text # string needs to be copied

--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -367,13 +367,13 @@ proc processEvents(app: App) =
 proc runQueuedFn(data: pointer): cint {.exportc.} =
   var fn = cast[ptr proc()](data)
   fn[]()
-  deallocShared(fn)
+  freeShared(fn)
   dec pQueue
   return 0
 
 proc queueMain(app: App, fn: proc()) =
   inc pQueue
-  var p = cast[ptr proc()](allocShared0(sizeof(proc())))
+  var p = createShared(proc())
   p[] = fn
   discard gdk_threads_add_idle(runQueuedFn, p)
 

--- a/src/nigui/private/gtk3/platform_impl.nim
+++ b/src/nigui/private/gtk3/platform_impl.nim
@@ -338,6 +338,8 @@ proc pCreateFont(fontFamily: string, fontSize: float, fontBold: bool): pointer =
 #                                    App Procedures
 # ----------------------------------------------------------------------------------------
 
+var queue: int
+
 proc init(app: App) =
   gtk_init(nil, nil)
 
@@ -366,12 +368,17 @@ proc runQueuedFn(data: pointer): cint {.exportc.} =
   var fn = cast[ptr proc()](data)
   fn[]()
   deallocShared(fn)
+  dec queue
   return 0
 
 proc queueMain(app: App, fn: proc()) =
+  inc queue
   var p = cast[ptr proc()](allocShared0(sizeof(proc())))
   p[] = fn
   discard gdk_threads_add_idle(runQueuedFn, p)
+
+proc queued(app: App): int =
+  return queue
 
 proc pClipboardTextReceivedFunc(clipboard: pointer, text: cstring, data: pointer): Gboolean {.cdecl.} =
   pClipboardText = $text # string needs to be copied

--- a/src/nigui/private/windows/platform_impl.nim
+++ b/src/nigui/private/windows/platform_impl.nim
@@ -348,7 +348,7 @@ proc pWindowWndProc(hWnd: pointer, uMsg: int32, wParam, lParam: pointer): pointe
   of pWM_QUEUED:
     let fn = cast[ptr proc()](wParam)
     fn[]()
-    deallocShared(fn)
+    freeShared(fn)
     dec pQueue
   else:
     discard
@@ -440,7 +440,7 @@ proc processEvents(app: App) =
 
 proc queueMain(app: App, fn: proc()) =
   inc pQueue
-  var p = cast[ptr proc()](allocShared0(sizeof(proc())))
+  var p = createShared(proc())
   p[] = fn
   if (not PostMessageA(pDefaultParentWindow, pWM_QUEUED, p, nil)):
     pRaiseLastOSError()


### PR DESCRIPTION
Currently if a thread calls `queueMain()` with a function containing GCed memory then exits, it will be freed, causing an invalid memory access. This adds a function that allows threads to wait for all queued functions to be executed before exiting.

Usage:

```nim
proc start() =
  {.gcsafe.}:
    # ...
    while app.queued() > 0:
      discard
```