### PR TITLE
Fixes for Mac OS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Run the [Nimble](https://github.com/nim-lang/nimble) install command: `$ nimble 
 
 * To disable the command line window under Windows, add this line to your Nim configuration: `--app:gui`
 * To compile a Windows binary which uses Gtk, add this line to your Nim configuration: `-d:forceGtk`
+* Under MacOS, install gtk3 with homebrew with `brew install gtk+3`
 
 ### How to verify the installation
 

--- a/src/nigui/private/gtk3/gtk3.nim
+++ b/src/nigui/private/gtk3/gtk3.nim
@@ -1,13 +1,26 @@
 # NiGui - minimal GTK+ 3 binding
 
 when defined(windows):
-  const libgtk3Path* = "libgtk-3-0.dll"
+  const libgtk3Path = "libgtk-3-0.dll"
+  {.pragma: libgtk3, cdecl, dynlib: libgtk3Path.}
 elif defined(macosx):
-  const libgtk3Path* = "libgtk-3.0.dylib"
+  import os
+  # Resolved at runtime (inside DatInit) so the binary works on any machine
+  # regardless of where Homebrew is installed.
+  # Priority: HOMEBREW_PREFIX env var → known locations → bare name fallback.
+  proc findGtk3LibPath(): string =
+    let envPrefix = getEnv("HOMEBREW_PREFIX")
+    if envPrefix.len > 0 and fileExists(envPrefix & "/lib/libgtk-3.0.dylib"):
+      return envPrefix & "/lib/libgtk-3.0.dylib"
+    if fileExists("/opt/homebrew/lib/libgtk-3.0.dylib"):
+      return "/opt/homebrew/lib/libgtk-3.0.dylib"
+    if fileExists("/usr/local/lib/libgtk-3.0.dylib"):
+      return "/usr/local/lib/libgtk-3.0.dylib"
+    return "libgtk-3.0.dylib"
+  {.pragma: libgtk3, cdecl, dynlib: findGtk3LibPath().}
 else:
-  const libgtk3Path* = "libgtk-3.so(|.0)"
-
-{.pragma: libgtk3, cdecl, dynlib: libgtk3Path.}
+  const libgtk3Path = "libgtk-3.so(|.0)"
+  {.pragma: libgtk3, cdecl, dynlib: libgtk3Path.}
 
 # ----------------------------------------------------------------------------------------
 #                                       Types


### PR DESCRIPTION
This PR fixes the search paths for the gtk library under MacOS, when installed with homebrew.
Should fix issues #63, #162 and maybe others.